### PR TITLE
Add PCA analysis and save attractor states

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
 # DiscreteRingAttractor
 MATLAB code for Noorman et al. (2024), Maintaining and updating accurate internal representations of continuous variables with a handful of neurons.
 
-All related data can be downloaded from Janelia Figshare (https://doi.org/10.25378/janelia.26169355). The function main.m contains instructions for generating all main and extended data figure panels. This relies on the Circular Statistics Toolbox (https://github.com/circstat/circstat-matlab). 
+All related data can be downloaded from Janelia Figshare (https://doi.org/10.25378/janelia.26169355). The function main.m contains instructions for generating all main and extended data figure panels. This relies on the Circular Statistics Toolbox (https://github.com/circstat/circstat-matlab).
+
+## Python example
+
+The repository also contains a lightweight Python reimplementation of the ring
+attractor dynamics. Run `simulate_attractors.py` to simulate drift from many
+initial orientations. When dependencies such as `numpy`, `scipy` and
+`matplotlib` are available, passing `plot=True` will display a heatmap of the
+activity, a scatter plot of initial vs. final orientations and a PCA
+visualization of the final states:
+
+```bash
+python simulate_attractors.py
+```
+
+The script saves the final bump orientations to `attractors.npy` and the
+corresponding activity vectors to `attractor_activity.npy`. It also computes an
+energy landscape over bump orientation and width, written to
+`energy_landscape.npy`.

--- a/ring_attractor.py
+++ b/ring_attractor.py
@@ -1,0 +1,271 @@
+import numpy as np
+from scipy.integrate import solve_ivp
+
+
+def poslin(x):
+    """Threshold linear function."""
+    return np.maximum(0.0, x)
+
+
+def dyn_sys(t, h, W, W_cw, W_ccw, C0, tau, v_fn, noise_fn):
+    """Continuous-time dynamics for the ring attractor.
+
+    Parameters
+    ----------
+    t : float
+        Current time.
+    h : ndarray
+        Activity vector of size N.
+    W, W_cw, W_ccw : ndarray
+        Connectivity matrices.
+    C0 : float
+        Constant feedforward input.
+    tau : float
+        Neuronal time constant.
+    v_fn : callable
+        Function returning the velocity input at time t.
+    noise_fn : callable
+        Function returning an additive noise vector at time t.
+    """
+    v = v_fn(t)
+    noise = noise_fn(t)
+
+    v_cw = max(v, 0.0)
+    v_ccw = max(-v, 0.0)
+
+    r = poslin(h)
+    dh = W @ r + v_cw * (W_cw @ r) + v_ccw * (W_ccw @ r) + noise
+    dh = (dh - h + C0) / tau
+    return dh
+
+
+def simulate(W, W_cw, W_ccw, C0, tau, v_fn, h0, t_span, dt, noise_fn=None):
+    """Simulate the network dynamics."""
+    if noise_fn is None:
+        noise_fn = lambda t: np.zeros_like(h0)
+
+    sol = solve_ivp(
+        dyn_sys,
+        (t_span[0], t_span[1]),
+        h0,
+        t_eval=np.arange(t_span[0], t_span[1] + dt, dt),
+        args=(W, W_cw, W_ccw, C0, tau, v_fn, noise_fn),
+        vectorized=False,
+    )
+    return sol.t, sol.y
+
+
+def bump_init(theta, psi, width, amplitude):
+    """Cosine shaped bump initialization."""
+    return amplitude * poslin(np.cos(theta - psi) - np.cos(width / 2.0))
+
+
+def compute_bump_state(h):
+    """Return bump orientation and width from activity matrix."""
+    N = h.shape[0]
+    dft = np.fft.fft(h, axis=0)
+    H0 = dft[0] / N
+    rho = np.abs(dft[1]) / N
+    psi = -np.angle(dft[1])
+    thc = np.arccos(-H0 / (2.0 * rho))
+    return psi, rho, thc
+
+
+def plot_dynamics(t, h, theta=None):
+    """Plot activity and bump orientation over time.
+
+    Parameters
+    ----------
+    t : ndarray
+        Time points returned by :func:`simulate`.
+    h : ndarray
+        Activity matrix with shape ``(N, len(t))``.
+    theta : ndarray, optional
+        Neuron angle for visualizing the heatmap. If ``None`` a uniform grid
+        over ``[0, 2π)`` is used.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The created figure instance.
+    """
+    import matplotlib.pyplot as plt
+
+    psi, _, _ = compute_bump_state(h)
+    if theta is None:
+        theta = np.linspace(0.0, 2 * np.pi, h.shape[0], endpoint=False)
+
+    fig, (ax_h, ax_psi) = plt.subplots(2, 1, figsize=(6, 5), sharex=True)
+    im = ax_h.imshow(
+        h,
+        aspect="auto",
+        origin="lower",
+        extent=[t[0], t[-1], theta[0], theta[-1]],
+        cmap="viridis",
+    )
+    ax_h.set_ylabel("Orientation")
+    fig.colorbar(im, ax=ax_h, label="Activity")
+
+    ax_psi.plot(t, psi, color="tab:red")
+    ax_psi.set_ylabel("Bump orientation")
+    ax_psi.set_xlabel("Time")
+
+    fig.tight_layout()
+    return fig
+
+
+def plot_attractor_map(initial_orientations, final_orientations):
+    """Scatter plot of initial vs. final bump orientations."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(4, 4))
+    ax.scatter(initial_orientations, final_orientations, color="tab:blue")
+    lims = [0, 2 * np.pi]
+    ax.plot(lims, lims, "k--", linewidth=1)
+    ax.set_xlim(lims)
+    ax.set_ylim(lims)
+    ax.set_xlabel("Initial orientation")
+    ax.set_ylabel("Final orientation")
+    ax.set_title("Attractor orientations")
+    fig.tight_layout()
+    return fig
+
+
+def pca_from_scratch(X):
+    """Compute PCA using eigen-decomposition of the covariance matrix.
+
+    Parameters
+    ----------
+    X : ndarray, shape (n_samples, n_features)
+        Data matrix where rows correspond to observations and columns to
+        variables (neurons).
+
+    Returns
+    -------
+    eigvals : ndarray
+        Eigenvalues in descending order.
+    eigvecs : ndarray
+        Corresponding eigenvectors (columns).
+    scores : ndarray
+        Projection of the centered data onto the eigenvectors.
+    """
+    X = np.asarray(X, dtype=float)
+    Xc = X - X.mean(axis=0, keepdims=True)
+    cov = Xc.T @ Xc / (Xc.shape[0] - 1)
+    eigvals, eigvecs = np.linalg.eigh(cov)
+    order = np.argsort(eigvals)[::-1]
+    eigvals = eigvals[order]
+    eigvecs = eigvecs[:, order]
+    scores = Xc @ eigvecs
+    return eigvals, eigvecs, scores
+
+
+def plot_pca(scores, orientations):
+    """Scatter points in the PC1-PC2 plane colored by orientation."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(4, 4))
+    sc = ax.scatter(scores[:, 0], scores[:, 1], c=orientations, cmap="hsv")
+    fig.colorbar(sc, ax=ax, label="Initial orientation")
+    ax.set_xlabel("PC1")
+    ax.set_ylabel("PC2")
+    ax.set_title("PCA of attractor states")
+    fig.tight_layout()
+    return fig
+
+
+def compute_energy(W, C0, h):
+    """Return the network energy for a given activity state.
+
+    Parameters
+    ----------
+    W : ndarray
+        Symmetric connectivity matrix of shape ``(N, N)``.
+    C0 : float
+        Constant feedforward input.
+    h : ndarray
+        Activity vector of shape ``(N,)`` or matrix ``(N, T)``.
+
+    Returns
+    -------
+    ndarray
+        Energy for each column of ``h``.
+    """
+    r = poslin(h)
+    if r.ndim == 1:
+        r = r[:, None]
+    Erec = -0.5 * np.einsum("ik,ij,jk->k", r, W, r)
+    Eext = -C0 * np.sum(r, axis=0)
+    Eleak = 0.5 * np.sum(r * r, axis=0)
+    return Erec + Eext + Eleak
+
+
+def _calculate_functions(psi, width, theta):
+    """Helper implementing the MATLAB ``calculateFunctions`` routine."""
+    N = len(theta)
+    p = psi % (2 * np.pi)
+    act = np.where((theta > p - width) & (theta < p + width))[0]
+    if p + width >= 2 * np.pi:
+        act = np.concatenate([act, np.where(theta < p + width - 2 * np.pi)[0]])
+    if p - width < 0:
+        act = np.concatenate([act, np.where(theta > p - width + 2 * np.pi)[0]])
+    if act.size == 0:
+        return np.nan, np.nan, np.nan
+    diff = np.cos(theta[act] - p) - np.cos(width)
+    fH0 = diff.mean()
+    frho = (diff * np.cos(theta[act] - p)).mean()
+    fpsi = (diff * np.sin(theta[act] - p)).mean()
+    return fH0 / N, frho / N, fpsi / N
+
+
+def energy_landscape(J1, J0, C0, theta, psi_samples, width_samples):
+    """Compute the energy landscape over ``psi`` and ``width``.
+
+    Parameters
+    ----------
+    J1, J0 : float
+        Amplitude and baseline of the cosine connectivity profile.
+    C0 : float
+        Constant feedforward input.
+    theta : ndarray
+        Preferred orientations of the neurons (size ``N``).
+    psi_samples : ndarray
+        Orientations at which to evaluate the energy.
+    width_samples : ndarray
+        Bump half widths.
+
+    Returns
+    -------
+    ndarray
+        Energy with shape ``(len(width_samples), len(psi_samples))``.
+    """
+    N = len(theta)
+    W = (J0 + J1 * np.cos(theta[:, None] - theta[None, :])) / N
+    E = np.zeros((len(width_samples), len(psi_samples)))
+    for i, psi in enumerate(psi_samples):
+        for j, w in enumerate(width_samples):
+            fH0, _, _ = _calculate_functions(psi, w, theta)
+            rho = -C0 / (2 * (np.cos(w) + J0 * fH0))
+            h = 2 * rho * (np.cos(theta - psi) - np.cos(w))
+            E[j, i] = compute_energy(W, C0, h)
+    return E
+
+
+def plot_energy_landscape(E, psi_samples, width_samples):
+    """Visualize an energy landscape heatmap."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(5, 4))
+    im = ax.imshow(
+        E,
+        aspect="auto",
+        origin="lower",
+        extent=[psi_samples[0], psi_samples[-1], 2 * width_samples[0], 2 * width_samples[-1]],
+        cmap="gray",
+    )
+    ax.set_xlabel("Orientation")
+    ax.set_ylabel("Bump width")
+    fig.colorbar(im, ax=ax, label="Energy")
+    ax.set_title("Energy landscape")
+    fig.tight_layout()
+    return fig

--- a/simulate_attractors.py
+++ b/simulate_attractors.py
@@ -1,0 +1,85 @@
+import numpy as np
+from ring_attractor import (
+    simulate,
+    bump_init,
+    compute_bump_state,
+    plot_dynamics,
+    plot_attractor_map,
+    pca_from_scratch,
+    plot_pca,
+    energy_landscape,
+    plot_energy_landscape,
+)
+
+
+def build_connectivity(N, JE=3.0, JI=-1.0, delta=np.pi/2, tau=0.1):
+    theta = np.linspace(0, 2 * np.pi, N, endpoint=False)
+    Ws = (JI + JE * np.cos(theta[:, None] - theta[None, :])) / N
+    Wa = np.cos(theta[:, None] - theta[None, :] + delta) / N
+    W = (Ws - np.eye(N)) / tau
+    W_cw = Wa / tau
+    W_ccw = Wa / tau
+    return theta, W, W_cw, W_ccw
+
+
+def main(plot=False):
+    N = 6
+    tau = 0.1
+    C0 = 1.0
+    A = 1.0
+    width = 3 * 2 * np.pi / N  # activate roughly 3 neurons
+    JE = 3.0
+    JI = -1.0
+    theta, W, W_cw, W_ccw = build_connectivity(N, JE=JE, JI=JI, tau=tau)
+
+    centers = np.linspace(0, np.pi / N, N, endpoint=False)
+    centers = np.concatenate([centers + k * (np.pi / N) for k in range(2 * N)])
+
+    attractors = []
+    final_states = []
+    example_t = None
+    example_h = None
+    for idx, psi in enumerate(centers):
+        h0 = bump_init(theta, psi, width, A)
+        t, h = simulate(
+            W,
+            np.zeros_like(W_cw),
+            np.zeros_like(W_ccw),
+            C0,
+            tau,
+            v_fn=lambda t: 0.0,
+            h0=h0,
+            t_span=(0.0, 5.0),
+            dt=0.01,
+        )
+        psi_traj, _, _ = compute_bump_state(h)
+        attractors.append(psi_traj[-1])
+        final_states.append(h[:, -1])
+
+        if idx == 0:
+            example_t = t
+            example_h = h
+
+    final_states = np.stack(final_states)
+
+    np.save("attractors.npy", np.array(attractors))
+    np.save("attractor_activity.npy", final_states)
+
+    eigvals, eigvecs, scores = pca_from_scratch(final_states)
+
+    psi_samples = np.linspace(0, 2 * np.pi, 200)
+    width_samples = np.linspace(np.pi / N, (N - 1) * np.pi / N, 200)
+    E_land = energy_landscape(JE, JI, C0, theta, psi_samples, width_samples)
+    np.save("energy_landscape.npy", E_land)
+
+    if plot and example_t is not None:
+        plot_dynamics(example_t, example_h, theta)
+        plot_attractor_map(centers, attractors)
+        plot_pca(scores, centers)
+        plot_energy_landscape(E_land, psi_samples, width_samples)
+        import matplotlib.pyplot as plt
+        plt.show()
+
+
+if __name__ == "__main__":
+    main(plot=True)


### PR DESCRIPTION
## Summary
- add `pca_from_scratch` and `plot_pca` utilities to `ring_attractor.py`
- store final activity states in `simulate_attractors.py` and analyze them with PCA
- visualize PC1/PC2 along with existing plots
- compute the energy landscape for the example parameters and show it when plotting
- note the new output files in the README
